### PR TITLE
BAU-3545 correct return type for AmountMoney/Pence classes

### DIFF
--- a/src/AmountMoney.php
+++ b/src/AmountMoney.php
@@ -32,7 +32,7 @@ class AmountMoney implements JsonSerializable
         $big = intval($parts[0]);
         $small = count($parts) > 1 ? intval(substr($parts[1].'00', 0, 2)) : 0;
 
-        return new self($big * 100 + $small);
+        return new static($big * 100 + $small);
     }
 
     /**
@@ -49,7 +49,7 @@ class AmountMoney implements JsonSerializable
      */
     public function minus(AmountMoney $amount): AmountMoney
     {
-        return new self($this->value - $amount->getValue());
+        return new static($this->value - $amount->getValue());
     }
 
     /**
@@ -58,7 +58,7 @@ class AmountMoney implements JsonSerializable
      */
     public function plus(AmountMoney $amount): AmountMoney
     {
-        return new self($this->value + $amount->getValue());
+        return new static($this->value + $amount->getValue());
     }
 
     /**

--- a/src/AmountPence.php
+++ b/src/AmountPence.php
@@ -17,7 +17,7 @@ class AmountPence extends AmountMoney
      */
     public function minus(AmountMoney $amount): AmountMoney
     {
-        return new self($this->value - $amount->getValue());
+        return new static($this->value - $amount->getValue());
     }
 
     /**
@@ -26,7 +26,7 @@ class AmountPence extends AmountMoney
      */
     public function plus(AmountMoney $amount): AmountMoney
     {
-        return new self($this->value + $amount->getValue());
+        return new static($this->value + $amount->getValue());
     }
 
     /**

--- a/tests/AmountMoneyTest.php
+++ b/tests/AmountMoneyTest.php
@@ -1,0 +1,40 @@
+<?php
+declare(strict_types=1);
+
+namespace Assertis\Util;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @author Rafał Orłowski <rafal.orlowski@assertis.co.uk>
+ */
+class AmountMoneyTest extends TestCase
+{
+
+    /**
+     * @return array
+     */
+    public function provideFromHumanReadableString(): array
+    {
+        return [
+            ['123.456', 12345],
+            ['123.45', 12345],
+            ['123.4', 12340],
+            ['123', 12300],
+            ['1,234.56', 123456],
+        ];
+    }
+
+    /**
+     * @dataProvider provideFromHumanReadableString
+     * @param string $string
+     * @param int $pence
+     */
+    public function testFromHumanReadableString(string $string, int $pence)
+    {
+        $price = AmountMoney::fromHumanReadableString($string);
+        self::assertInstanceOf(AmountMoney::class, $price);
+        self::assertSame($pence, $price->getValue());
+    }
+
+}

--- a/tests/AmountPenceTest.php
+++ b/tests/AmountPenceTest.php
@@ -53,6 +53,8 @@ class AmountPenceTest extends PHPUnit_Framework_TestCase
      */
     public function testFromHumanReadableString(string $string, int $pence)
     {
-        self::assertSame($pence, AmountPence::fromHumanReadableString($string)->getValue());
+        $price = AmountPence::fromHumanReadableString($string);
+        self::assertInstanceOf(AmountPence::class, $price);
+        self::assertSame($pence, $price->getValue());
     }
 }


### PR DESCRIPTION
self always call class method is declared in.
static call class which called particular method (possibly childclass).
