### PR TITLE
Mutex for memcached

### DIFF
--- a/src/DistributedMemcacheMutex.php
+++ b/src/DistributedMemcacheMutex.php
@@ -4,6 +4,7 @@ namespace Assertis\Util;
 
 use InvalidArgumentException;
 use Memcache;
+use Memcached;
 
 /**
  * Utility methods for manipulating distributed locks using memcache
@@ -16,7 +17,7 @@ class DistributedMemcacheMutex
     /**
      * @var Memcache
      */
-    private $memcache;
+    protected $memcache;
 
     /**
      * @param Memcache $memcache
@@ -44,7 +45,7 @@ class DistributedMemcacheMutex
     /**
      * @throws InvalidArgumentException
      */
-    private function assertServersAddedToMemcache()
+    protected function assertServersAddedToMemcache()
     {
         if ($this->memcache->getversion() === false) {
             throw new InvalidArgumentException(self::MEMCACHE_ERR_MSG);

--- a/src/DistributedMemcacheMutex.php
+++ b/src/DistributedMemcacheMutex.php
@@ -4,7 +4,6 @@ namespace Assertis\Util;
 
 use InvalidArgumentException;
 use Memcache;
-use Memcached;
 
 /**
  * Utility methods for manipulating distributed locks using memcache

--- a/src/DistributedMemcachedMutex.php
+++ b/src/DistributedMemcachedMutex.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+namespace Assertis\Util;
+
+use Memcached;
+
+/**
+ * This class should be used when we will migrate to PHP 7.2
+ * It extends DistributedMemcacheMutex because all other methods like add, remove etc.
+ * are available in memcached also so there is no reason to overwrite methods.
+ *
+ * @author Łukasz Nowak <lukasz.nowak@assertis.co.uk>
+ * Class DistributedMemcachedMutex
+ * @package Assertis\Util
+ */
+class DistributedMemcachedMutex extends DistributedMemcacheMutex
+{
+
+    /**
+     * DistributedMemcachedMutex constructor.
+     * @param Memcached $memcached
+     */
+    public function __construct(Memcached $memcached)
+    {
+        $this->memcache = $memcached;
+    }
+}

--- a/tests/DistributedMemcachedMutexTest.php
+++ b/tests/DistributedMemcachedMutexTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Assertis\Util;
+
+use InvalidArgumentException;
+use PHPUnit_Framework_TestCase;
+
+class DistributedMemcachedMutexTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var DistributedMemcachedMutex
+     */
+    private $mutex;
+    /**
+     * @var DistributedMemcachedMutex
+     */
+    private $serverlessMutex;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+        $memcached = new MemcachedStub();
+        $memcachedWithoutServers = new MemcachedStub();
+        $this->mutex = new DistributedMemcachedMutex($memcached->withServersAdded());
+        $this->serverlessMutex = new DistributedMemcachedMutex($memcachedWithoutServers);
+    }
+
+    /**
+     * @test
+     */
+    public function lockWhenMemcacheKeyDoesNotExist()
+    {
+        try {
+            $this->mutex->lock('some_key');
+            $this->success();
+        } catch (AlreadyLockedException $exception) {
+            $this->fail($exception->getMessage());
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function lockThrowsExceptionWhenMemcacheKeyExists()
+    {
+        try {
+            $this->mutex->lock('some_key');
+            $this->mutex->lock('some_key');
+            $this->fail('DistributedMemcachedMutex::lock method should throw AlreadyLockedException.');
+        } catch (AlreadyLockedException $exception) {
+            $this->success();
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function unlockWhenMemcacheKeyExists()
+    {
+        try {
+            $this->mutex->lock('some_key');
+            $this->mutex->unlock('some_key');
+            $this->mutex->lock('some_key');
+            $this->success();
+        } catch (AlreadyLockedException $exception) {
+            $this->fail($exception->getMessage(). ' It should not exists because it was unlocked.');
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function unlockWhenMemcacheKeyDoesNotExist()
+    {
+        try {
+            $this->mutex->unlock('some_key');
+            $this->mutex->lock('some_key');
+            $this->success();
+        } catch (AlreadyLockedException $exception) {
+            $this->fail($exception->getMessage(). ' It should not exists because it was not present.');
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function lockWhenNoServers()
+    {
+        try {
+            $this->serverlessMutex->lock('some_key');
+            $this->fail('DistributedMemcachedMutex::lock method should throw InvalidArgumentException.');
+        } catch (InvalidArgumentException $exception) {
+            $this->success();
+        }
+    }
+
+    private function success()
+    {
+        $this->assertTrue(true);
+    }
+}

--- a/tests/MemcachedStub.php
+++ b/tests/MemcachedStub.php
@@ -2,12 +2,12 @@
 
 namespace Assertis\Util;
 
-use Memcache;
+use Memcached;
 
 /**
  * @author Mateusz Angulski <mateusz.angulski@assertis.co.uk>
  */
-class MemcacheStub extends Memcache
+class MemcachedStub extends Memcached
 {
     /**
      * @var array
@@ -19,20 +19,19 @@ class MemcacheStub extends Memcache
     private $areServersAdded = false;
 
     /**
-     * @return MemcacheStub
+     * @return MemcachedStub
      */
     public function withServersAdded()
     {
-        $withServers = clone $this;
-        $withServers->areServersAdded = true;
+        $this->areServersAdded = true;
 
-        return $withServers;
+        return $this;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function add($key, $var, $expire)
+    public function add($key, $var, $expire = NULL)
     {
         if (array_key_exists($key, $this->cache)) {
             return false;


### PR DESCRIPTION
I'll need it in nrs-service. Because if we want to use docker there I need to rid out memcache and use memcached.

I also noticed that when you install `php7` in alpine it installs php7.2 where memcache doesn't work, but memcached does. So in future if we want to migrate on our live to php7.2 we should be aware of that.