### PR TITLE
Memcached handle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,9 @@
     "php": "^7.0",
     "ext-SimpleXML": "*",
     "ext-dom": "*",
-    "psr/log": "^1.0"
+    "psr/log": "^1.0",
+    "ext-memcached": "*",
+    "ext-memcache": "*"
   },
   "require-dev": {
     "symfony/var-dumper": "^4.0",

--- a/composer.json
+++ b/composer.json
@@ -15,9 +15,7 @@
     "php": "^7.0",
     "ext-SimpleXML": "*",
     "ext-dom": "*",
-    "psr/log": "^1.0",
-    "ext-memcached": "*",
-    "ext-memcache": "*"
+    "psr/log": "^1.0"
   },
   "require-dev": {
     "symfony/var-dumper": "^4.0",

--- a/src/DistributedMemcacheMutex.php
+++ b/src/DistributedMemcacheMutex.php
@@ -8,11 +8,8 @@ use Memcache;
 /**
  * Utility methods for manipulating distributed locks using memcache
  */
-class DistributedMemcacheMutex
+class DistributedMemcacheMutex extends DistributedMutex
 {
-    const FIVE_MINUTES_SECONDS = 300;
-    const MEMCACHE_ERR_MSG = 'No servers added to memcache connection.';
-
     /**
      * @var Memcache
      */
@@ -49,13 +46,5 @@ class DistributedMemcacheMutex
         if ($this->memcache->getversion() === false) {
             throw new InvalidArgumentException(self::MEMCACHE_ERR_MSG);
         }
-    }
-
-    /**
-     * @param string $name
-     */
-    public function unlock($name)
-    {
-        $this->memcache->delete($name);
     }
 }

--- a/src/DistributedMemcachedMutex.php
+++ b/src/DistributedMemcachedMutex.php
@@ -3,19 +3,20 @@ declare(strict_types=1);
 
 namespace Assertis\Util;
 
+use InvalidArgumentException;
 use Memcached;
 
 /**
  * This class should be used when we will migrate to PHP 7.2
- * It extends DistributedMemcacheMutex because all other methods like add, remove etc.
- * are available in memcached also so there is no reason to overwrite methods.
  *
  * @author Łukasz Nowak <lukasz.nowak@assertis.co.uk>
+ * @author Bartłomiej Olewiński <bartlomiej.olewinski@assertis.co.uk>
  * Class DistributedMemcachedMutex
  * @package Assertis\Util
  */
-class DistributedMemcachedMutex extends DistributedMemcacheMutex
+class DistributedMemcachedMutex extends DistributedMutex
 {
+    const MEMCACHE_RESPOND_ERR_MSG = 'Server %s not responding.';
 
     /**
      * DistributedMemcachedMutex constructor.
@@ -24,5 +25,36 @@ class DistributedMemcachedMutex extends DistributedMemcacheMutex
     public function __construct(Memcached $memcached)
     {
         $this->memcache = $memcached;
+    }
+
+    /**
+     * @param string $name
+     * @param int $expirationTimeInSeconds
+     *
+     * @throws InvalidArgumentException
+     * @throws AlreadyLockedException
+     */
+    public function lock($name, $expirationTimeInSeconds = self::FIVE_MINUTES_SECONDS)
+    {
+        $this->assertServersAddedToMemcachedAndResponding();
+
+        if (false === $this->memcache->add($name, 1, $expirationTimeInSeconds)) {
+            throw new AlreadyLockedException($name);
+        }
+    }
+
+    protected function assertServersAddedToMemcachedAndResponding()
+    {
+        $serverVersions = $this->memcache->getversion();
+
+        if (count($serverVersions) == 0) {
+            throw new InvalidArgumentException(self::MEMCACHE_ERR_MSG);
+        }
+
+        foreach($serverVersions as $server => $version) {
+            if ($version == '255.255.255') { //https://secure.php.net/manual/en/memcached.getversion.php#111539
+                throw new InvalidArgumentException(sprintf(self::MEMCACHE_RESPOND_ERR_MSG, $server));
+            }
+        }
     }
 }

--- a/src/DistributedMemcachedMutex.php
+++ b/src/DistributedMemcachedMutex.php
@@ -51,7 +51,7 @@ class DistributedMemcachedMutex extends DistributedMutex
             throw new InvalidArgumentException(self::MEMCACHE_ERR_MSG);
         }
 
-        foreach($serverVersions as $server => $version) {
+        foreach ($serverVersions as $server => $version) {
             if ($version == '255.255.255') { //https://secure.php.net/manual/en/memcached.getversion.php#111539
                 throw new InvalidArgumentException(sprintf(self::MEMCACHE_RESPOND_ERR_MSG, $server));
             }

--- a/src/DistributedMutex.php
+++ b/src/DistributedMutex.php
@@ -19,6 +19,8 @@ abstract class DistributedMutex
      */
     protected $memcache;
 
+    abstract public function lock($name, $expirationTimeInSeconds);
+
     /**
      * @param string $name
      */

--- a/src/DistributedMutex.php
+++ b/src/DistributedMutex.php
@@ -5,7 +5,6 @@
 
 namespace Assertis\Util;
 
-
 use Memcache;
 use Memcached;
 

--- a/src/DistributedMutex.php
+++ b/src/DistributedMutex.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * @author Bartłomiej Olewiński <bartlomiej.olewinski@gmail.com>
+ */
+
+namespace Assertis\Util;
+
+
+use Memcache;
+use Memcached;
+
+abstract class DistributedMutex
+{
+    const FIVE_MINUTES_SECONDS = 300;
+    const MEMCACHE_ERR_MSG = 'No servers added to memcache connection.';
+
+    /**
+     * @var Memcache|Memcached
+     */
+    protected $memcache;
+
+    /**
+     * @param string $name
+     */
+    public function unlock($name)
+    {
+        $this->memcache->delete($name);
+    }
+}

--- a/tests/MemcachedStub.php
+++ b/tests/MemcachedStub.php
@@ -16,15 +16,14 @@ class MemcachedStub extends Memcached
     /**
      * @var bool
      */
-    private $areServersAdded = false;
+    private $serversAdded = [];
 
     /**
      * @return MemcachedStub
      */
     public function withServersAdded()
     {
-        $this->areServersAdded = true;
-
+        $this->serversAdded = ['localhost:11211' => '1.2.6'];
         return $this;
     }
 
@@ -59,6 +58,6 @@ class MemcachedStub extends Memcached
      */
     public function getversion()
     {
-        return $this->areServersAdded;
+        return $this->serversAdded;
     }
 }


### PR DESCRIPTION
As Memchache and MemcacheD are 2 different classess (without common abstraction), DistributedMemcacheDMutex shouldn't inherit from DistributedMemcacheMutex, especially when it overwrites constructor without calling parent's constructor and works on different injected class (MemcacheD)
They should inherit from some abstract class. (or implement interface at least)